### PR TITLE
Support Rack Timeout v5+

### DIFF
--- a/lib/slowpoke.rb
+++ b/lib/slowpoke.rb
@@ -19,7 +19,8 @@ module Slowpoke
   end
 
   def self.timeout=(timeout)
-    @timeout = timeout.to_i if timeout.respond_to?(:to_i)
+    timeout = timeout.to_i if timeout.respond_to?(:to_i)
+    @timeout = timeout
   end
 
   def self.migration_statement_timeout

--- a/lib/slowpoke.rb
+++ b/lib/slowpoke.rb
@@ -10,7 +10,12 @@ module Slowpoke
   ENV_KEY = "slowpoke.timed_out".freeze
 
   def self.timeout
-    @timeout ||= (ENV["REQUEST_TIMEOUT"] || ENV["TIMEOUT"] || 15).to_i
+    @timeout ||= (
+      ENV["RACK_TIMEOUT_SERVICE_TIMEOUT"] ||
+      ENV["REQUEST_TIMEOUT"] ||
+      ENV["TIMEOUT"] ||
+      15
+    ).to_i
   end
 
   def self.timeout=(timeout)

--- a/lib/slowpoke.rb
+++ b/lib/slowpoke.rb
@@ -14,8 +14,7 @@ module Slowpoke
   end
 
   def self.timeout=(timeout)
-    timeout = timeout.to_i if timeout.respond_to?(:to_i)
-    @timeout = Rack::Timeout.service_timeout = timeout
+    @timeout = timeout.to_i if timeout.respond_to?(:to_i)
   end
 
   def self.migration_statement_timeout

--- a/lib/slowpoke/railtie.rb
+++ b/lib/slowpoke/railtie.rb
@@ -1,11 +1,12 @@
 module Slowpoke
   class Railtie < Rails::Railtie
     initializer "slowpoke" do |app|
-      Rack::Timeout.service_timeout = Slowpoke.timeout
       if Rails::VERSION::MAJOR >= 5
-        app.config.middleware.insert_after ActionDispatch::DebugExceptions, Rack::Timeout
+        app.config.middleware.insert_after ActionDispatch::DebugExceptions, Rack::Timeout,
+          service_timeout: Slowpoke.timeout
       else
-        app.config.middleware.insert_before ActionDispatch::RemoteIp, Rack::Timeout
+        app.config.middleware.insert_before ActionDispatch::RemoteIp, Rack::Timeout,
+          service_timeout: Slowpoke.timeout
       end
       app.config.middleware.insert(0, Slowpoke::Middleware) unless Rails.env.development? || Rails.env.test?
     end

--- a/slowpoke.gemspec
+++ b/slowpoke.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "railties"
   spec.add_dependency "actionpack"
-  spec.add_dependency "rack-timeout", ">= 0.3.0", "< 0.5.0"
+  spec.add_dependency "rack-timeout", ">= 0.4.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
(Also drops support for everything < 4.0.0)

Rack does not have top-level class accessors for setting timeout, but instead is configurable when inserting the middleware or with ENV vars.

This means that `Slowpoke.timeout=` only sets its own local state and must be done before the Middleware is inserted. However, based on the source of earlier `Rack::Timeout` versions, I think this was likely always the case anyway from at least v4+, which the current gem already supports, so in theory this does not introduce a breaking change for anybody already on rack-timeout 4+ and on the latest slowpoke.

I also tweaked the default timeouts to check `RACK_TIMEOUT_SERVICE_TIMEOUT`, which provides a clean upgrade path for those adding Slowpoke to an existing app with `Rack::Timeout` already configured.