### PR TITLE
Use TERM signal for Puma

### DIFF
--- a/lib/slowpoke/middleware.rb
+++ b/lib/slowpoke/middleware.rb
@@ -14,6 +14,8 @@ module Slowpoke
         # can't do in timed_out state consistently
         if defined?(::PhusionPassenger)
           `passenger-config detach-process #{Process.pid}`
+        elsif defined?(::Puma)
+          Process.kill("TERM", Process.pid)
         else
           Process.kill("QUIT", Process.pid)
         end


### PR DESCRIPTION
Puma handles TERM gracefully: "TERM send TERM to worker. Worker will attempt to finish then exit." (https://github.com/puma/puma/blob/master/docs/signals.md)

With QUIT, any other requests that had been queued up for the worker are cancelled, causing users to randomly experience 500 errors on unrelated requests